### PR TITLE
fix(db): remove empty line after rollback (closes #37)

### DIFF
--- a/cmd/galvanico-db/migrate.go
+++ b/cmd/galvanico-db/migrate.go
@@ -21,10 +21,10 @@ var migrateCmd = &cobra.Command{
 				return err
 			}
 			if group.IsZero() {
-				log.Info().Msgf("there are no new migrations to run (database is up to date)\n")
+				log.Info().Msgf("there are no new migrations to run (database is up to date)")
 				return nil
 			}
-			log.Info().Msgf("migrated to %s\n", group)
+			log.Info().Msgf("migrated to %s", group)
 			return nil
 		})
 	},

--- a/cmd/galvanico-db/rollback.go
+++ b/cmd/galvanico-db/rollback.go
@@ -20,7 +20,7 @@ var rollbackCmd = &cobra.Command{
 				log.Info().Msg("there are no groups to roll back")
 				return nil
 			}
-			log.Info().Msgf("rolled back %s\n", group)
+			log.Info().Msgf("rolled back %s", group)
 			return nil
 		})
 	},


### PR DESCRIPTION
Fixes #37

**Changes:**
- Zerolog automatically appends newline characters to log entries.  
Removing '\n' additions to prevent duplicate newlines in log output.  