### PR TITLE
feat(design): fix annoying fade translation between route change

### DIFF
--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -20,6 +20,10 @@
 
 .fade-enter-from, .fade-leave-to {
   opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
 }
 
 .fade-enter-to, .fade-leave-from {

--- a/client/src/views/Auth/Layout.vue
+++ b/client/src/views/Auth/Layout.vue
@@ -15,19 +15,22 @@ onMounted(() => {
 <template>
   <div class="flex justify-center">
     <div class="card w-96 bg-base-100 shadow-xl mt-20 mb-20">
-      <div class="card-body">
-        <h1>Galvanico</h1>
+      <div class="card-body relative">
+        <h1 class="text-bold text-center text-xl">
+          <RouterLink :to="{name: `home`}">Galvanico</RouterLink>
+        </h1>
 
-        <RouterView v-slot="{Component}">
-          <transition name="fade">
-            <component :is="Component"/>
-          </transition>
-        </RouterView>
+        <div class="transition-wrapper relative">
+          <RouterView v-slot="{Component}">
+            <transition name="fade">
+              <component :is="Component"/>
+            </transition>
+          </RouterView>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-
 </style>

--- a/client/src/views/Auth/Layout.vue
+++ b/client/src/views/Auth/Layout.vue
@@ -16,7 +16,7 @@ onMounted(() => {
   <div class="flex justify-center">
     <div class="card w-96 bg-base-100 shadow-xl mt-20 mb-20">
       <div class="card-body relative">
-        <h1 class="text-bold text-center text-xl">
+        <h1 class="text-center text-xl">
           <RouterLink :to="{name: `home`}">Galvanico</RouterLink>
         </h1>
 

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -10,10 +10,12 @@ import {isAuthenticated} from "@/services/auth.ts";
         <p class="py-6">
           {{ $t('index.imprint') }}
         </p>
+        <div>
         <RouterLink :to="{name: isAuthenticated() ? `game.index` : `auth.register`}"
-                    class="btn btn-primary">
+                    class="btn btn-soft btn-primary">
           {{ $t('index.getStarted') }}
         </RouterLink>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved fade transition effects for smoother visual appearance during page changes by adjusting element positioning.
  - Updated layout and styling in the authentication view, including a redesigned heading with a clickable link and enhanced structure.
  - Adjusted button styling on the home view for a softer appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->